### PR TITLE
feat(Redis): add `db` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.0 - Sep 11, 2023
+
+- Feat: add `db` option to worker config
+
 ## 1.5.1 - Sep 20, 2022
 
 - Chore: Upgrade dependencies with Dependabot security alerts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "346b10598869bcdcd53cd166ecfb04ff8a4d5d7bb33e4ef4acbdb2a447ac3c73"
 
 [[package]]
 name = "froman"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "froman"
-version = "1.5.1"
+version = "1.6.0"
 authors = ["Tim Morgan <tim@timmorgan.org>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ apps:
   check-ins:
     path: ../check-ins
     sidekiq:
-      namespace: check-ins-sidekiq-development
       command: bundle exec sidekiq
+      db: 12
   services:
     path: ../services
     resque:

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,7 @@ fn build_workers(config: &Yaml, debug: bool) -> Vec<Box<dyn Worker>> {
                                 .as_str()
                                 .unwrap_or("")
                                 .to_string(),
+                            db: worker_config["db"].as_i64().unwrap_or(0).to_string(),
                             command: worker_config["command"]
                                 .as_str()
                                 .expect("could not get start command as string")
@@ -159,6 +160,7 @@ fn build_workers(config: &Yaml, debug: bool) -> Vec<Box<dyn Worker>> {
                                 .as_str()
                                 .unwrap_or("")
                                 .to_string(),
+                            db: worker_config["db"].as_i64().unwrap_or(0).to_string(),
                             command: worker_config["command"]
                                 .as_str()
                                 .expect("could not get start command as string")

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -24,12 +24,15 @@ impl<'a> Runner<'a> {
 
     pub fn run(&mut self, workers: &mut Vec<Box<dyn Worker>>) -> FromanResult<()> {
         let interval = Duration::from_secs(2);
-        let redis = redis::Client::open(self.config.redis_url.as_str()).unwrap();
-        let redis_conn = redis.get_connection()?;
         let label_size = self.get_label_size(&workers);
         println!("Froman monitoring queues...");
         loop {
             for (worker_index, mut worker) in workers.iter_mut().enumerate() {
+                let redis = redis::Client::open(
+                    format!("{}{}", self.config.redis_url.as_str(), worker.db()).as_str(),
+                )
+                .unwrap();
+                let redis_conn = redis.get_connection()?;
                 let color = COLORS[worker_index % COLORS.len()];
                 self.work(&mut worker, &redis_conn, color, label_size)?;
             }

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -14,6 +14,7 @@ pub trait Worker {
     fn path(&self) -> &String;
     fn command(&self) -> &String;
     fn kind(&self) -> &str;
+    fn db(&self) -> &String;
     fn work_to_do(&self, _: &redis::Connection) -> FromanResult<bool>;
     fn work_being_done(&self, _: &redis::Connection) -> FromanResult<bool>;
     fn process(&self) -> &Option<Child>;
@@ -60,6 +61,7 @@ pub struct Sidekiq {
     pub app: String,
     pub path: String,
     pub namespace: String,
+    pub db: String,
     pub command: String,
     pub process: Option<Child>,
     pub terminate_at: Option<DateTime<Local>>,
@@ -80,6 +82,10 @@ impl Worker for Sidekiq {
 
     fn kind(&self) -> &str {
         "sidekiq"
+    }
+
+    fn db(&self) -> &String {
+        &self.db
     }
 
     fn work_to_do(&self, redis_conn: &redis::Connection) -> FromanResult<bool> {
@@ -133,6 +139,7 @@ impl Worker for Sidekiq {
 pub struct Resque {
     pub app: String,
     pub path: String,
+    pub db: String,
     pub namespace: String,
     pub command: String,
     pub process: Option<Child>,
@@ -150,6 +157,10 @@ impl Worker for Resque {
 
     fn command(&self) -> &String {
         &self.command
+    }
+
+    fn db(&self) -> &String {
+        &self.db
     }
 
     fn kind(&self) -> &str {


### PR DESCRIPTION
Support for `redis-namespace` was [removed in Sidekiq 7][s7].

In response, have `froman` support `db` as an alternative to `namespace` for checking if there is `work_to_do`

As far as I could tell, there's no way to access multiple dbs with the same connection. So the major change here is to `runner.rs` where we create a separate `redis_conn` for each `Worker`.

[s7]: https://www.mikeperham.com/2022/10/27/introducing-sidekiq-7.0/